### PR TITLE
Update patch_handler.py

### DIFF
--- a/patch_handler.py
+++ b/patch_handler.py
@@ -71,7 +71,7 @@ class PatchHandler():
         num_patches = ratio_over_micro[0] * ratio_over_micro[1]
 
         # Step 1: micro patches -> stripes of images
-        merge_stage1 = tf.reshape(x, [-1, num_patches*self.micro_patch_size[0], self.micro_patch_size[1], 3])
+        merge_stage1 = tf.reshape(x, [-1, num_patches*self.micro_patch_size[0], self.micro_patch_size[1], self.c_dim])
         slices = []
         for i in range(ratio_over_micro[1]):
             slice_st = [0, self.micro_patch_size[0]*ratio_over_micro[0]*i, 0, 0]


### PR DESCRIPTION
When I run the COCO-GAN on my gray image dataset, I find it failed with the error "tensorflow.python.framework.errors.InvalidArgumentError: Input to reshape is a tensor with xxx values, but the requested shape requires a multiple of xxx values" in patch_handler.py.
So I modified the last value of tf.reshape to self.c_dim and it worked.



